### PR TITLE
添加mathjax内联函数支持

### DIFF
--- a/packages/hexo-theme-async/source/css/_components/index.less
+++ b/packages/hexo-theme-async/source/css/_components/index.less
@@ -21,3 +21,4 @@
 @import "./tag-plugins.less";
 @import "./plugins/index.less";
 @import "./fixed-btn.less";
+@import "./mathjax-inline.less";


### PR DESCRIPTION
原来的mathjax会默认输出为块级公式，即便只有一层$包裹。
现在，经过修改之后，可以正常展示内联函数
效果展示
![image](https://github.com/user-attachments/assets/9672ad93-49e4-43d5-bf1c-8faeb1b0c544)
原来的情况：
![image](https://github.com/user-attachments/assets/41f43935-181d-4f82-aabe-3280386e084b)

具体改动：
head.ejs中添加link，连接到mathjax-inline.css
在source/css/_components/中添加mathjax-inline.less
然后添加到了_components/index.less中