### PR TITLE
添加mathjax内联函数支持

### DIFF
--- a/packages/hexo-theme-async/layout/_partial/head.ejs
+++ b/packages/hexo-theme-async/layout/_partial/head.ejs
@@ -60,6 +60,7 @@
 
 <!-- Theme mode css -->
 <link data-swup-theme rel="stylesheet" href="<%= url_for('css/index.css') %>?v=<%= theme.version %>" id="trm-switch-style">
+<link rel="stylesheet" href="<%= url_for('css/mathjax-inline.css') %>">
 <script>
     let defaultMode = ASYNC_CONFIG.theme.default !=='auto' ?  ASYNC_CONFIG.theme.default : (window.matchMedia("(prefers-color-scheme: light)").matches ? 'style-light' : 'style-dark')
     let catchMode = localStorage.getItem('theme-mode') || defaultMode;

--- a/packages/hexo-theme-async/source/css/_components/index.less
+++ b/packages/hexo-theme-async/source/css/_components/index.less
@@ -21,3 +21,4 @@
 @import "./tag-plugins.less";
 @import "./plugins/index.less";
 @import "./fixed-btn.less";
+@import "./mathjax-inline.less";

--- a/packages/hexo-theme-async/source/css/_components/mathjax-inline.less
+++ b/packages/hexo-theme-async/source/css/_components/mathjax-inline.less
@@ -1,15 +1,33 @@
+/* 内联公式 */
 mjx-container[jax="SVG"][display="false"] {
-    display: inline-block !important;
-  }
-  .math.inline,
-  .math.inline mjx-container {
-    display: inline-block !important;
-    vertical-align: middle;
-  }
-  mjx-container {
-    max-width: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-    display: inline-flex !important;
-  }
-  
+  display: inline-block !important;
+  vertical-align: middle;
+}
+
+/* 块级公式 */
+mjx-container[jax="SVG"][display="true"] {
+  display: block !important;
+  margin: 1em 0;
+  text-align: center;
+  padding: 12px 0;
+}
+
+/* 公共设置 */
+mjx-container {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+/* 自定义容器 */
+.math.inline,
+.math.inline mjx-container[jax="SVG"] { /* 增加属性限定 */
+  display: inline-block !important;
+  vertical-align: middle;
+}
+
+/* 代码块中的公式 */
+pre mjx-container {
+  display: inline !important;
+  padding: 0 !important;
+}

--- a/packages/hexo-theme-async/source/css/_components/mathjax-inline.less
+++ b/packages/hexo-theme-async/source/css/_components/mathjax-inline.less
@@ -1,0 +1,15 @@
+mjx-container[jax="SVG"][display="false"] {
+    display: inline-block !important;
+  }
+  .math.inline,
+  .math.inline mjx-container {
+    display: inline-block !important;
+    vertical-align: middle;
+  }
+  mjx-container {
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    display: inline-flex !important;
+  }
+  


### PR DESCRIPTION
原来的mathjax会默认输出为块级公式，即便只有一层$包裹。
现在，经过修改之后，可以正常展示内联函数
效果展示
![image](https://github.com/user-attachments/assets/4bb9b0f7-822b-4896-b90b-1b2dd92600bf)

原来的情况：
![image](https://github.com/user-attachments/assets/1eae3c1b-a837-43ea-bf50-4e89af09f28a)

具体改动：
head.ejs中添加link，连接到mathjax-inline.css
在source/css/_components/中添加mathjax-inline.less
然后添加到了_components/index.less中